### PR TITLE
ci: bump checkout & setup-node to v5 (Node 24 runtime)

### DIFF
--- a/.arch/goals/ci-actions-node24.md
+++ b/.arch/goals/ci-actions-node24.md
@@ -1,0 +1,31 @@
+---
+slug: ci-actions-node24
+title: Migrate GitHub Actions off the deprecated Node 20 runtime (bump checkout/setup-node to v5)
+status: in-progress
+created: 2026-06-06
+exit-criteria:
+  - actions/checkout and actions/setup-node are pinned to @v5 (Node 24 runtime) in BOTH .github/workflows/ci.yml and .github/workflows/release.yml
+  - No remaining @v4 references to checkout/setup-node anywhere under .github/workflows/
+  - The next CI run on the change shows no 'Node.js 20 actions are deprecated' annotation and the workflow stays green (npm ci, check:versions, npm test)
+- The next CI run on the change shows no 'Node.js 20 actions are deprecated' annotation and the workflow stays green (npm ci, check: versions, npm test)
+files-to-touch:
+  - .github/workflows/ci.yml
+  - .github/workflows/release.yml
+required-reading: 
+depends-on: 
+verify-command: npm test
+source-ask: After the v1.9.1 release, the CI run surfaced a deprecation warning: actions/checkout@v4 and actions/setup-node@v4 run on Node.js 20, forced to Node 24 after 2026-06-16. Turn the follow-up into a CGR goal.
+started: 2026-06-06
+---
+
+
+# Migrate GitHub Actions off the deprecated Node 20 runtime (bump checkout/setup-node to v5)
+
+## Why
+The v1.9.1 release run flagged that actions/checkout@v4 and actions/setup-node@v4 run on Node 20, which GitHub forces to Node 24 after 2026-06-16 and removes 2026-09-16. Bumping to the v5 majors (Node 24 runtime) clears the deprecation before it becomes a hard break.
+
+## Exit criteria
+- [ ] actions/checkout and actions/setup-node are pinned to @v5 (Node 24 runtime) in BOTH .github/workflows/ci.yml and .github/workflows/release.yml
+- [ ] No remaining @v4 references to checkout/setup-node anywhere under .github/workflows/
+- [ ] The next CI run on the change shows no 'Node.js 20 actions are deprecated' annotation and the workflow stays green (npm ci, check:versions, npm test)
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: npm


### PR DESCRIPTION
## Why
The v1.9.1 release run flagged `actions/checkout@v4` and `actions/setup-node@v4` as running on the deprecated **Node 20** action runtime — GitHub force-migrates these to Node 24 after **2026-06-16** and removes the Node 20 runtime entirely on **2026-09-16**.

## What
Pin both actions to the `@v5` majors (Node 24 runtime) in:
- `.github/workflows/ci.yml`
- `.github/workflows/release.yml`

No behavior change — `node-version: 20` (the Node used to run npm scripts) is untouched; only the actions' own runtime moves to Node 24.

## Verification
- `npm test` green locally (45/45 suites)
- No remaining `@v4` references under `.github/workflows/`
- CI run on this PR should show **no** "Node.js 20 actions are deprecated" annotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)